### PR TITLE
add genesis_hash to Asset

### DIFF
--- a/asset_controller_api/v1/asset.proto
+++ b/asset_controller_api/v1/asset.proto
@@ -78,6 +78,8 @@ message Asset {
   bytes notary_signature   = 9;
   // List of Notaries.
   repeated Notary notaries = 10;
+  // Genesis hash of all fields in Promissory
+  string genesis_hash      = 11;
 }
 
 /* [Example]


### PR DESCRIPTION
- Added genesis_hash field to Asset message. 
- This is part of a two part ticket, https://github.com/knox-networks/service-protos/issues/9. The other piece is to update core to set the new genesis_hash field to the string value of the promissory.genesis_hash function.